### PR TITLE
Make upptime check autumn.revolt.chat base-domain

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -6,7 +6,7 @@ sites:
   - name: API
     url: https://api.revolt.chat
   - name: CDN
-    url: https://autumn.revolt.chat/healthcheck
+    url: https://autumn.revolt.chat
   - name: Voice
     url: https://vortex.revolt.chat
   - name: Proxy Service


### PR DESCRIPTION
Solves #295 which has been open for DAYS at this point... I have to ask if you even monitor this repository in all honesty...

Anyways, the autumn domain is now just the domain itself without the /healthcheck, which seems to be gone.
And given the domain itself seems to give a success response, it could be used as a replacement now.